### PR TITLE
Add all jpackage options for --type

### DIFF
--- a/src/main/java/ru/akman/maven/plugins/jpackage/JPackageMojo.java
+++ b/src/main/java/ru/akman/maven/plugins/jpackage/JPackageMojo.java
@@ -829,6 +829,18 @@ public class JPackageMojo extends BaseToolMojo {
         case MSI:
           opt.createArg().setValue("msi");
           break;
+        case RPM:
+          opt.createArg().setValue("rpm");
+          break;
+        case DEB:
+          opt.createArg().setValue("deb");
+          break;
+        case PKG:
+          opt.createArg().setValue("pkg");
+          break;
+        case DMG:
+          opt.createArg().setValue("dmg");
+          break;
         default:
           // skip
       }

--- a/src/main/java/ru/akman/maven/plugins/jpackage/PackageType.java
+++ b/src/main/java/ru/akman/maven/plugins/jpackage/PackageType.java
@@ -23,5 +23,9 @@ public enum PackageType {
   PLATFORM,
   IMAGE,
   EXE,
-  MSI
+  MSI,
+  RPM,
+  DEB,
+  PKG,
+  DMG
 }


### PR DESCRIPTION
This PR adds all options for `--type` to the `<type>` configuration.
This is useful for, e.g. building both rpm and deb packages on a linux box where rpmtools, fakeroot and dpkg-deb are
installed.