### PR TITLE
 #15 - Upgrade plexus-java to 1.2.0 to support JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <version.junit>4.13.2</version.junit>
     <version.file-management>3.1.0</version.file-management>
     <version.maven-plugin-testing-harness>3.3.0</version.maven-plugin-testing-harness>
-    <version.plexus-java>1.1.1</version.plexus-java>
+    <version.plexus-java>1.2.0</version.plexus-java>
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.commons-text>1.9</version.commons-text>
 


### PR DESCRIPTION
## Fix

Upgrade plexus-java to 1.2.0 so that the plugin could build project which is using JDK 21.

## Context

The issue some how described in #15, while package the project using this plugin, I faced the error:

```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 65
    at org.objectweb.asm.ClassReader.<init> (ClassReader.java:199)
    at org.objectweb.asm.ClassReader.<init> (ClassReader.java:180)
    at org.objectweb.asm.ClassReader.<init> (ClassReader.java:166)
    at org.objectweb.asm.ClassReader.<init> (ClassReader.java:287)
    at org.codehaus.plexus.languages.java.jpms.AsmModuleInfoParser.parse (AsmModuleInfoParser.java:51)
    at org.codehaus.plexus.languages.java.jpms.AbstractBinaryModuleInfoParser.getModuleDescriptor (AbstractBinaryModuleInfoParser.java:50)
    at org.codehaus.plexus.languages.java.jpms.AbstractBinaryModuleInfoParser.getModuleDescriptor (AbstractBinaryModuleInfoParser.java:38)
    at org.codehaus.plexus.languages.java.jpms.LocationManager.getMainModuleDescriptor (LocationManager.java:338)
    at org.codehaus.plexus.languages.java.jpms.LocationManager.resolvePaths (LocationManager.java:155)
    at ru.akman.maven.plugins.jpackage.JPackageMojo.resolveDependencies (JPackageMojo.java:1328)
    at ru.akman.maven.plugins.jpackage.JPackageMojo.execute (JPackageMojo.java:1875)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

